### PR TITLE
Keep compatibility with ruby < 2.0.0 by locking slop

### DIFF
--- a/zk-server.gemspec
+++ b/zk-server.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler', '>= 1'
   s.add_runtime_dependency 'slyphon-log4j', '= 1.2.15'
   s.add_runtime_dependency 'slyphon-zookeeper_jar', '~> 3.3.5'
-  s.add_runtime_dependency 'slop', '>= 3.2.0'
+  s.add_runtime_dependency 'slop', '>= 3.2.0', '< 4.0'
 
   s.files         = `git ls-files`.split($\)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
the build is failing on this pull request because slop 4.0+ is not compatible with ruby < 2.0.0

https://github.com/zk-ruby/zookeeper/pull/74/