### PR TITLE
Reset namespace, conflicts with zk v1.9.6

### DIFF
--- a/lib/zk-server/logging.rb
+++ b/lib/zk-server/logging.rb
@@ -1,7 +1,7 @@
 module ZK
   module Server
     # default logger instance
-    @logger ||= Logger.new($stderr).tap { |l| l.level = Logger::FATAL }
+    @logger ||= ::Logger.new($stderr).tap { |l| l.level = ::Logger::FATAL }
 
     class << self
       attr_accessor :logger
@@ -20,4 +20,3 @@ module ZK
     end
   end
 end
-


### PR DESCRIPTION
Fixes compatibility with the latest zk gem version

/cc @slyphon @eric 
